### PR TITLE
API 호출이 가능하도록 인증 설정 변경하기

### DIFF
--- a/src/main/java/com/example/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectboard/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers("/api/**").permitAll() // /api 요청에 대해 인증 요구 안함
                         .mvcMatchers(
                                 HttpMethod.GET,
                                 "/",
@@ -49,6 +50,7 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService)
                         )
                 )
+                .csrf(csrf -> csrf.ignoringAntMatchers("/api/**")) // /api 로 시작하는 모든 요청은 csrf 설정 보지 않겠다.
                 .build();
     }
 


### PR DESCRIPTION
이 pr은 외부 서비스(어드민 서비스)에서 원활하게 게시판 서비스의 데이터 api를 이용할 수 있도록 시큐리티 설정을 업데이트 한다.

This closes #101 